### PR TITLE
Adding back valid Alt attribute, correcting an Aria issue upstream. [Work-In-Progess]

### DIFF
--- a/src/lib/components.jsx
+++ b/src/lib/components.jsx
@@ -23,7 +23,7 @@ export function SVG(props : SVGProps) : ElementNode {
     if (typeof svg !== 'string') {
         throw new TypeError(`Expected svg prop to be a string or jsx node`);
     }
-
+    
     // $FlowFixMe
     const svgProps = {
         src: svgToBase64(svg),
@@ -39,15 +39,16 @@ export function SVG(props : SVGProps) : ElementNode {
 export type SVGLogoProps = {
     render : () => ElementNode,
     name : string,
+    alt? : string,
     logoColor? : $Values<typeof LOGO_COLOR>
 };
 
-export function SVGLogo({ render, name, logoColor, ...props } : SVGLogoProps) : ComponentNode<SVGLogoProps> {
+export function SVGLogo({ render, name, alt, logoColor, ...props } : SVGLogoProps) : ComponentNode<SVGLogoProps> {
     return (
         <SVG
             { ...props }
             svg={ render() }
-            alt=''
+            alt={ `${ alt ?  alt : capitalizeFirstLetter(name) }` }
             class={ `${ LOGO_CLASS.LOGO } ${ LOGO_CLASS.LOGO }-${ name } ${ logoColor ? `${ LOGO_CLASS.LOGO_COLOR }-${ logoColor }` : '' }` }
         />
     );


### PR DESCRIPTION
## Problem  
<!-- What problem are you trying to solve? -->
[PayPal buttons have the incorrect aria-label](https://paypal.slack.com/archives/CDE52GDFT/p1603344735183900) 


## Solution 
<!-- How did you solve the problem? -->
Logos are currently not providing an `Alt` attribute, so when they are ultimately passed in to `funding/content.jsx` in [paypal-checkout-components](https://github.com/paypal/paypal-checkout-components/blob/50ec5294000d6adb0e916f6f4090d5b291458c45/src/funding/content.jsx#L71), they don't provide a text value, causing the aria-label to be rendered with a missing word.  

This adds back the alt tag for logo images which were removed [here](https://github.com/paypal/paypal-sdk-logos/pull/11/), solving this issue? 

<!-- ## How to Review -->
<!-- Where should they start their review? -->
<!-- Call out areas of high concern and areas that can be ignored -->
<!-- Leave inline comments for your reviewer -->

<!-- ## Demo / Repro -->
<!-- Describe the steps required to view the changes -->

<!-- ## Requirements --> 
## Additional Context
https://engineering.paypalcorp.com/jira/browse/DTCHKINT-300
<!-- Include links for related content PRs, related docs / information, UI specs, stories, RFC, etc -->
