### PR TITLE
Remove `aria-label`'s and add `role` to SVG logos

### DIFF
--- a/src/logos/paypal/logo.jsx
+++ b/src/logos/paypal/logo.jsx
@@ -41,6 +41,7 @@ export function PayPalLogo({ logoColor = LOGO_COLOR.DEFAULT, ...props } : { logo
             { ...props }
             name={ LOGO.PAYPAL }
             alt='PayPal'
+            role='presentation'
             logoColor={ logoColor }
             render={ () => (
                 <svg width="101px" height="32" viewBox="0 0 101 32" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
@@ -99,6 +100,7 @@ export function PPLogo({ logoColor = LOGO_COLOR.DEFAULT, ...props } : { logoColo
             { ...props }
             name={ LOGO.PP }
             alt='PP'
+            role='presentation'
             logoColor={ logoColor }
             render={ () => {
                 return (

--- a/src/logos/paypal/logo.jsx
+++ b/src/logos/paypal/logo.jsx
@@ -41,7 +41,6 @@ export function PayPalLogo({ logoColor = LOGO_COLOR.DEFAULT, ...props } : { logo
             { ...props }
             name={ LOGO.PAYPAL }
             alt='PayPal'
-            aria-label='PayPal'
             logoColor={ logoColor }
             render={ () => (
                 <svg width="101px" height="32" viewBox="0 0 101 32" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">

--- a/src/logos/paypal/logo.jsx
+++ b/src/logos/paypal/logo.jsx
@@ -99,7 +99,6 @@ export function PPLogo({ logoColor = LOGO_COLOR.DEFAULT, ...props } : { logoColo
             { ...props }
             name={ LOGO.PP }
             alt='PP'
-            aria-label='PP'
             logoColor={ logoColor }
             render={ () => {
                 return (


### PR DESCRIPTION
### Purpose

This PR removes the `aria-label`'s and adds `role=presentation` to the PayPal and PayPal Credit SVG logos.

Before:
![Screen Shot 2021-12-15 at 10 57 45 AM](https://user-images.githubusercontent.com/20399044/146248436-1aba2527-412a-416f-bdf9-0681dc74f64e.png)

After:
![Screen Shot 2021-12-15 at 11 58 36 AM](https://user-images.githubusercontent.com/20399044/146248468-7d3e32af-299e-4145-8539-23cc82e1f27c.png)

### JIRA Ticket 
https://engineering.paypalcorp.com/jira/browse/DTPPSDK-582

### Comments
This has been tested w/ a screenreader. Before and after demo videos are available upon request.