### PR TITLE
fix: run build-logos after versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,6 @@ jobs:
           git config --global user.email ${{ github.actor }}@users.noreply.github.com
           git config --global user.name ${{ github.actor }}
 
-      - name: Update cdn folder with new svg files
-        run: npm run build-logos -- --commit
-
       - name: Publish to npm
         run: npm run release
         env:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "build-logos": "babel-node --config-file './scripts/babel.config.json' --ignore ./fake --plugins=transform-es2015-modules-commonjs ./scripts/buildLogos.js"
   },
   "standard-version": {
+    "scripts": {
+      "postbump": "npm run build-logos -- --commit"
+    },
     "types": [
       {
         "type": "feat",


### PR DESCRIPTION
Fix to make build-logos script run after package.json version bump on publish