### PR TITLE
fix: fix types and getCDNUrl logic

### DIFF
--- a/src/lib/components.jsx
+++ b/src/lib/components.jsx
@@ -75,6 +75,8 @@ export function SVGLogo({
 export type SVGCardLogoProps = {
   render: () => ElementNode,
   name: string,
+  cdnUrl?: string,
+  loadFromCDN?: boolean,
 };
 
 export function SVGCardLogo({

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -45,7 +45,7 @@ export function getLogoCDNUrl(
   logoColorMap?: LogoColorMap,
   logoColor?: $Values<typeof LOGO_COLOR>
 ): string {
-  if (logoColor && logoColorMap && !logoColorMap[logoColor]) {
+  if (logoColorMap && (!logoColor || !logoColorMap[logoColor])) {
     logoColor = LOGO_COLOR.DEFAULT;
   }
 

--- a/src/logos/card/amex/logo.jsx
+++ b/src/logos/card/amex/logo.jsx
@@ -41,7 +41,10 @@ export const getAmexSVG = (): ElementNode => {
 
 export function AmexLogo({
   ...props
-}: { [string]: string } = {}): ComponentNode<SVGCardLogoProps> {
+}: {
+  loadFromCDN?: boolean,
+  [string]: string,
+} = {}): ComponentNode<SVGCardLogoProps> {
   const svg = getAmexSVG();
   const cdnUrl = getLogoCDNUrl(CARD.AMEX);
 

--- a/src/logos/card/discover/logo.jsx
+++ b/src/logos/card/discover/logo.jsx
@@ -94,7 +94,10 @@ export const getDiscoverSVG = (): ElementNode => {
 
 export function DiscoverLogo({
   ...props
-}: { [string]: string } = {}): ComponentNode<SVGCardLogoProps> {
+}: {
+  loadFromCDN?: boolean,
+  [string]: string,
+} = {}): ComponentNode<SVGCardLogoProps> {
   const svg = getDiscoverSVG();
   const cdnUrl = getLogoCDNUrl(CARD.DISCOVER);
 

--- a/src/logos/card/elo/logo.jsx
+++ b/src/logos/card/elo/logo.jsx
@@ -70,7 +70,10 @@ export const getEloSVG = (): ElementNode => {
 
 export function EloLogo({
   ...props
-}: { [string]: string } = {}): ComponentNode<SVGCardLogoProps> {
+}: {
+  loadFromCDN?: boolean,
+  [string]: string,
+} = {}): ComponentNode<SVGCardLogoProps> {
   const svg = getEloSVG();
   const cdnUrl = getLogoCDNUrl(CARD.ELO);
 

--- a/src/logos/card/glyph/logo.jsx
+++ b/src/logos/card/glyph/logo.jsx
@@ -57,6 +57,7 @@ export function GlyphCard({
   ...props
 }: {
   logoColor?: $Values<typeof LOGO_COLOR>,
+  loadFromCDN?: boolean,
   [string]: string,
 } = {}): ComponentNode<SVGCardLogoProps> {
   const svg = getGlyphCardSVG(

--- a/src/logos/card/hiper/logo.jsx
+++ b/src/logos/card/hiper/logo.jsx
@@ -63,7 +63,10 @@ export const getHiperSVG = (): ElementNode => {
 
 export function HiperLogo({
   ...props
-}: { [string]: string } = {}): ComponentNode<SVGCardLogoProps> {
+}: {
+  loadFromCDN?: boolean,
+  [string]: string,
+} = {}): ComponentNode<SVGCardLogoProps> {
   const svg = getHiperSVG();
   const cdnUrl = getLogoCDNUrl(CARD.HIPER);
 

--- a/src/logos/card/jcb/logo.jsx
+++ b/src/logos/card/jcb/logo.jsx
@@ -167,7 +167,10 @@ export const getJcbSVG = (): ElementNode => {
 
 export function JcbLogo({
   ...props
-}: { [string]: string } = {}): ComponentNode<SVGCardLogoProps> {
+}: {
+  loadFromCDN?: boolean,
+  [string]: string,
+} = {}): ComponentNode<SVGCardLogoProps> {
   const svg = getJcbSVG();
   const cdnUrl = getLogoCDNUrl(CARD.JCB);
 

--- a/src/logos/card/mastercard/logo.jsx
+++ b/src/logos/card/mastercard/logo.jsx
@@ -49,7 +49,10 @@ export const getMastercardSVG = (): ElementNode => {
 
 export function MastercardLogo({
   ...props
-}: { [string]: string } = {}): ComponentNode<SVGCardLogoProps> {
+}: {
+  loadFromCDN?: boolean,
+  [string]: string,
+} = {}): ComponentNode<SVGCardLogoProps> {
   const svg = getMastercardSVG();
   const cdnUrl = getLogoCDNUrl(CARD.MASTERCARD);
 

--- a/src/logos/card/visa/logo.jsx
+++ b/src/logos/card/visa/logo.jsx
@@ -37,7 +37,10 @@ export const getVisaSVG = (): ElementNode => {
 
 export function VisaLogo({
   ...props
-}: { [string]: string } = {}): ComponentNode<SVGCardLogoProps> {
+}: {
+  loadFromCDN?: boolean,
+  [string]: string,
+} = {}): ComponentNode<SVGCardLogoProps> {
   const svg = getVisaSVG();
   const cdnUrl = getLogoCDNUrl(CARD.VISA);
 


### PR DESCRIPTION
* Added missing props to `SVGCardLogoProps`
* Slightly reworked logic for `getLogoCDNUrl` to correctly handle an edge case where users to pass no `logoColor` prop to logos which have color variants.