### PR TITLE
fix: Update Logo Names

### DIFF
--- a/src/logos/card/glyphRebrand/logo.jsx
+++ b/src/logos/card/glyphRebrand/logo.jsx
@@ -83,7 +83,7 @@ export function GlyphCardRebrandInlineSVG({
   return (
     <SVGLogo
       {...props}
-      name={LOGO.CARD}
+      name={LOGO.CARD_REBRAND}
       render={() => {
         return svg;
       }}

--- a/src/logos/paypalRebrand/logo.jsx
+++ b/src/logos/paypalRebrand/logo.jsx
@@ -191,7 +191,7 @@ export function PPRebrandLogoExternalImage({
   return (
     <SVGLogo
       {...props}
-      name={LOGO.PP}
+      name={LOGO.PP_REBRAND}
       alt="PP"
       role="presentation"
       logoColor={logoColor}
@@ -207,13 +207,13 @@ export function PPRebrandLogoInlineSVG({
   logoColor?: $Values<typeof LOGO_COLOR>,
 }): ComponentNode<SVGLogoProps> {
   const svg = getPPRebrandSVG(
-    getLogoColors(LOGO.PP, PP_REBRAND_LOGO_COLORS, logoColor)
+    getLogoColors(LOGO.PP_REBRAND, PP_REBRAND_LOGO_COLORS, logoColor)
   );
 
   return (
     <SVGLogo
       {...props}
-      name={LOGO.PP}
+      name={LOGO.PP_REBRAND}
       alt="PP"
       role="presentation"
       logoColor={logoColor}

--- a/src/logos/venmoRebrand/logo.jsx
+++ b/src/logos/venmoRebrand/logo.jsx
@@ -88,7 +88,7 @@ export function VenmoRebrandLogoExternalImage({
   return (
     <SVGLogo
       {...props}
-      name={LOGO.VENMO}
+      name={LOGO.VENMO_REBRAND}
       logoColor={logoColor}
       cdnUrl={cdnUrl}
     />
@@ -108,7 +108,7 @@ export function VenmoRebrandLogoInlineSVG({
   return (
     <SVGLogo
       {...props}
-      name={LOGO.VENMO}
+      name={LOGO.VENMO_REBRAND}
       logoColor={logoColor}
       render={() => {
         return svg;


### PR DESCRIPTION
Updates Logo names to included `rebrand` so we can easily run test on the legacy vs rebrand experince.