### PR TITLE
feat: remove whitespace from PP monogram logo

### DIFF
--- a/src/logos/paypalRebrand/logo.jsx
+++ b/src/logos/paypalRebrand/logo.jsx
@@ -152,8 +152,8 @@ export const getPPRebrandSVG = ({
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="20"
-      height="34"
-      viewBox="0 0 20 34"
+      height="26.15"
+      viewBox="0 3.925 20 26.15"
       fill="none"
     >
       <g clip-path="url(#clip0_4189_85875)">


### PR DESCRIPTION
## What is the purpose of this PR?

This PR adjusts the PP monogram SVG dimensions to remove excess vertical whitespace. The `height` was changed from `34` to `26.15` and the `viewBox` adjusted from `0 0 20 34` to `0 3.925 20 26.15` to tightly crop around the visible logo content, consistent with the whitespace trimming applied to other rebranded logos in PR #136.

**Jira Ticket:** [DTPPCPSDK-6251](https://paypal.atlassian.net/browse/DTPPCPSDK-6251)

## Type of change

- [ ] New feature (backward compatible change that adds new capability).
- [x] UI change
- [ ] Bug fix.
- [ ] Breaking change (backward incompatible change). Provide references to customer impact and communication.
- [ ] Refactor (no functional change)

## Testing Plan

Below is information that validates the successful implementation of this feature and how a release manager can validate the success of a release candidate in the absence of the PR author.

**PR Author:** [Nik Roman](https://paypal.enterprise.slack.com/team/U05UEBPF2P9)

**Backup Validator:** [Delaney Barrow](https://paypal.enterprise.slack.com/team/U08CJGPCH98)

**PR Author's Team:** PayPal JS SDK

**Test Environment URL:** N/A

### Step-by-Step Validation

1. Import the updated `paypal-sdk-logos` package in a consuming application
2. Render the PP monogram logo and verify the vertical whitespace has been removed
3. Confirm the logo renders without visual clipping or distortion at the new dimensions

### Rollback Considerations

Are there any services dependent on this change?

- [ ] Yes
- [x] No